### PR TITLE
Добавить возможность форсировать игровой статус через команду /st

### DIFF
--- a/pewpewbot/State.py
+++ b/pewpewbot/State.py
@@ -27,7 +27,7 @@ class State:
     koline: Koline = None
 
     async def dump_params(
-        self, file_path: Path, ignore_fields: list = ["game_status", "koline"]
+            self, file_path: Path, ignore_fields: list = ["game_status", "koline"]
     ):
         params_dict = asdict(self)
         for key in ignore_fields:
@@ -46,7 +46,6 @@ class State:
                 pass
         logging.info(f"Parameters loaded from {file_path}")
 
-
     def reset(self, field_name):
         """
         Resets field to default value.
@@ -61,6 +60,13 @@ class State:
             setattr(self, field_name, field.default_factory())
         else:
             setattr(self, field_name, field.default)
+
+    def reset_all(self):
+        """
+        Resets all fields to default values.
+        """
+        for field_name in self.__dataclass_fields__:
+            self.reset(field_name)
 
     def set_tip(self, tip):
         sector_tips = [sector_tip.strip() for sector_tip in tip.split("***")]

--- a/pewpewbot/State.py
+++ b/pewpewbot/State.py
@@ -85,7 +85,7 @@ class State:
             raise AttributeError(f"Attribute {name} does not exist in State")
         field = self.__dataclass_fields__[name]
         field_type = field.type
-        if isinstance(value, field_type):  # if value type matches field
+        if isinstance(value, field_type) or value is None:  # if value type matches field
             super().__setattr__(name, value)
         elif field_type is int and isinstance(value, str):  # casts str to int
             super().__setattr__(name, int(value))

--- a/pewpewbot/State.py
+++ b/pewpewbot/State.py
@@ -13,7 +13,7 @@ class State:
     type_on: bool = False
     maps_on: bool = True
     tip: list = field(default_factory=list)  # Should be list[list[str]]
-    link: str = ""
+    link: str = "http://classic.dzzzr.ru/moscow/go/"
     code_chat_id: str = None
     main_chat_id: str = None
     debug_chat_id: str = None

--- a/pewpewbot/State.py
+++ b/pewpewbot/State.py
@@ -14,17 +14,17 @@ class State:
     maps_on: bool = True
     tip: list = field(default_factory=list)  # Should be list[list[str]]
     link: str = "http://classic.dzzzr.ru/moscow/go/"
-    code_chat_id: str = None
-    main_chat_id: str = None
-    debug_chat_id: str = None
+    code_chat_id: str = field(default=None)
+    main_chat_id: str = field(default=None)
+    debug_chat_id: str = field(default=None)
     engine_timeout: int = 30
-    screenshot_url: str = None
+    screenshot_url: str = field(default=None)
     screenshot_timeout: int = 5
     screenshot_height: int = 1000
     screenshot_width: int = 1000
     code_pattern: str = patterns.STANDARD_CODE_PATTERN
-    game_status: Status = None
-    koline: Koline = None
+    game_status: Status = field(default=None)
+    koline: Koline = field(default=None)
 
     async def dump_params(
             self, file_path: Path, ignore_fields: list = ["game_status", "koline"]

--- a/pewpewbot/bot.py
+++ b/pewpewbot/bot.py
@@ -6,7 +6,6 @@ from pewpewbot.screenshot import Screenshoter
 import commands_processing
 from pewpewbot.command_patterns import COMMAND_MANAGER
 from os import path
-from functools import partial
 from logging import config
 from aiogram import Bot, Dispatcher, executor
 from pewpewbot import utils
@@ -43,19 +42,18 @@ def main():
         try:
             state.load_params(state_file_path)
         except Exception as exc:
-            logger.warn("Failed to load params", exc_info=exc)
-    screenshoter = Screenshoter(loop=loop) # Can use separate loop here
+            logger.warning("Failed to load params", exc_info=exc)
+    screenshoter = Screenshoter(loop=loop)  # Can use separate loop here
     manager = Manager(state, Client(), screenshoter, bot, logging.getLogger(Manager.__name__))
     try:
         asyncio.ensure_future(manager.http_client.log_in(login, password), loop=loop)
     except Exception as e:
         logging.error("Failed to login")
 
-
-    loop.create_task(utils.repeat_runtime_delay(manager, 'engine_timeout', commands_processing.update_level_status, bot, manager))
+    loop.create_task(
+        utils.repeat_runtime_delay(manager, 'engine_timeout', commands_processing.update_level_status, bot, manager))
     loop.create_task(utils.repeat_runtime_delay(manager, 'screenshot_timeout', screenshoter.update_screenshot, state))
     loop.create_task(utils.repeat_const_delay(DUMP_CONFIG_TIMEOUT, state.dump_params, state_file_path))
-
 
     # Create dispatcher
     dispatcher = Dispatcher(bot)

--- a/pewpewbot/command_patterns.py
+++ b/pewpewbot/command_patterns.py
@@ -83,6 +83,15 @@ COMMAND_MANAGER.add_commands(
         enabled=True,
     ),
     TgCommand(
+        names="pin_chat",
+        help_text="""
+        /pin_chat - используется с одним из аргументов: main, code, debug. Устанавливает chat_id из которого было 
+        отправлено сообщение и ставит в соответствие необходимому параметру: main_chat_id/code_chat_id/debug_chat_id
+        """,
+        awaitable_action_method=commands_processing.pin_chat,
+        enabled=True,
+    ),
+    TgCommand(
         names="parse",
         help_text="""
         /parse - парсинг движка дозора, /parse on, /parse off для переключения режима. /status, чтобы узнать,

--- a/pewpewbot/command_patterns.py
+++ b/pewpewbot/command_patterns.py
@@ -165,6 +165,15 @@ COMMAND_MANAGER.add_commands(
         enabled=True,
     ),
     TgCommand(
+        names="reset",
+        help_text="""
+        /reset позволяет сбросить все параметры статуса бота в стандартные значения. Для сброса конкретного параметра
+        нужно использовать /reset key. 
+        """,
+        awaitable_action_method=commands_processing.reset_default,
+        enabled=True,
+    ),
+    TgCommand(
         names="get_params",
         help_text="""
         /get_params позволяет узнать все текущие установленные параметры

--- a/pewpewbot/command_patterns.py
+++ b/pewpewbot/command_patterns.py
@@ -170,7 +170,7 @@ COMMAND_MANAGER.add_commands(
         /reset позволяет сбросить все параметры статуса бота в стандартные значения. Для сброса конкретного параметра
         нужно использовать /reset key. 
         """,
-        awaitable_action_method=commands_processing.reset_default,
+        awaitable_action_method=commands_processing.reset_to_default,
         enabled=True,
     ),
     TgCommand(

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -267,7 +267,10 @@ async def _process_next_level(status, manager: Manager, silent=True):
         schema_urls = utils.get_schema_urls(status.current_level.question)
         if len(schema_urls):
             for schema_url in schema_urls:
-                await utils.image_to_all_channels(manager, "Схема захода: \n", schema_url)
+                try:
+                    await utils.image_to_all_channels(manager, "Схема захода: \n", schema_url)
+                except Exception as e:
+                    await utils.notify_code_chat()
         else:
             await utils.notify_all_channels(manager, "Схема захода: Не удалось распарсить")
     if status.current_level.locationComment:
@@ -365,6 +368,18 @@ async def process_unknown(message: types.Message, manager: Manager, **kwargs):
 
 async def process_get_chat_id(message: types.Message, manager: Manager, **kwargs):
     await message.reply("chat id: {}".format(message.chat.id))
+
+
+async def pin_chat(message: types.Message, manager: Manager, **kwargs):
+    if 'main' in message.text:
+        manager.state.main_chat_id = message.chat.id
+        await message.reply("Установлен чат для организационной информации")
+    elif 'code' in message.text:
+        manager.state.code_chat_id = message.chat.id
+        await message.reply("Установлен чат для ввода кодов и штабных трансляций")
+    elif 'debug' in message.text:
+        manager.state.debug_chat_id = message.chat.id
+        await message.reply("Установлен чат для дебажных отчетов")
 
 
 async def set_state_key_value(message: types.Message, manager: Manager, **kwargs):

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -372,14 +372,16 @@ async def process_get_chat_id(message: types.Message, manager: Manager, **kwargs
 
 async def pin_chat(message: types.Message, manager: Manager, **kwargs):
     if 'main' in message.text:
-        manager.state.main_chat_id = message.chat.id
+        setattr(manager.state, 'main_chat_id', str(message.chat.id))
         await message.reply("Установлен чат для организационной информации")
     elif 'code' in message.text:
-        manager.state.code_chat_id = message.chat.id
+        setattr(manager.state, 'code_chat_id', str(message.chat.id))
         await message.reply("Установлен чат для ввода кодов и штабных трансляций")
     elif 'debug' in message.text:
-        manager.state.debug_chat_id = message.chat.id
+        setattr(manager.state, 'debug_chat_id', str(message.chat.id))
         await message.reply("Установлен чат для дебажных отчетов")
+    else:
+        await message.reply("Используйте один из допустимых аргументов: main, code, debug")
 
 
 async def set_state_key_value(message: types.Message, manager: Manager, **kwargs):

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -323,17 +323,20 @@ async def _update_current_level_info_on_code(verdict: str, message: types.Messag
 @safe_dzzzr_interaction
 async def update_level_status(bot: Bot, manager: Manager, **kwargs):
     forced_update = 'game_status' in kwargs
-    game_status = kwargs['game_status']
-    if manager.state.parse_on or forced_update:
-        if not forced_update:
-            game_status = await manager.http_client.status()
-        current_level_id = game_status.current_level.levelNumber
-        if not manager.state.game_status:
-            return await _process_next_level(game_status, manager)
-        if manager.state.game_status.current_level.levelNumber != current_level_id:
-            return await _process_next_level(game_status, manager, silent=False)
-        else:
-            return _update_current_level_info(game_status, manager)
+    game_status = None
+    if forced_update:
+        game_status = kwargs['game_status']
+    elif manager.state.parse_on:
+        game_status = await manager.http_client.status()
+    if not game_status or not game_status.current_level:
+        return
+    current_level_id = game_status.current_level.levelNumber
+    # To avoid dummy messages to the chats on the bot or game startup
+    if not manager.state.game_status:
+        return await _process_next_level(game_status, manager)
+    if manager.state.game_status.current_level.levelNumber != current_level_id:
+        return await _process_next_level(game_status, manager, silent=False)
+    return _update_current_level_info(game_status, manager)
 
 
 async def try_process_coords(message: types.Message, manager: Manager, text: str):

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -416,3 +416,4 @@ async def reset_to_default(message: types.Message, manager: Manager, **kwargs):
             await message.reply(f"Переменной {key} не существует")
     else:
         manager.state.reset_all()
+        await message.reply("Выполнен сброс к заводским настройкам")

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -243,7 +243,8 @@ async def update_level(message: types.Message, manager: Manager, **kwargs):
             await message.reply('Не удалось распарсить игровой статус: {}'.format(e))
     else:
         game_status = await manager.http_client.status()
-    await message.reply(str(game_status))
+    # TODO: to be solved properly in issue #32
+    await message.reply(str(game_status)[:4000])
     await update_level_status(manager.bot, manager, **{'game_status': game_status})
 
 
@@ -381,7 +382,8 @@ async def set_state_key_value(message: types.Message, manager: Manager, **kwargs
 async def get_all_params(message: types.Message, manager: Manager, **kwargs):
     values = asdict(manager.state)
     text = "\n".join(f"{key}: {value}" for key, value in values.items())
-    await message.reply(f"Все заданные переменные:\n{text}")
+    # TODO: to be solved properly in issue #32
+    await message.reply(f"Все заданные переменные:\n{text[:4000]}")
 
 
 async def get_version(message: types.Message, manager: Manager, **kwargs):

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -404,3 +404,15 @@ async def get_all_params(message: types.Message, manager: Manager, **kwargs):
 async def get_version(message: types.Message, manager: Manager, **kwargs):
     msg = os.environ.get("VERSION", "Не задана")
     await message.reply(f"Версия бота: {msg}")
+
+
+def reset_default(message: types.Message, manager: Manager, **kwargs):
+    key = utils.trim_command_name(message, kwargs['command_name']).strip()
+    if len(key):
+        try:
+            manager.state.reset(key)
+            await message.reply(f"Для переменной {key} установлено значение: {getattr(manager.state, key)}")
+        except AttributeError:
+            await message.reply(f"Переменной {key} не существует")
+    else:
+        manager.state.reset_all()

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -233,8 +233,8 @@ async def update_level(message: types.Message, manager: Manager, **kwargs):
     if len(message.text) >= len("/st "):
         dict_or_url = message.text[3:].strip()
         if not dict_or_url.startswith('{'):
-            status_dict = requests.get(dict_or_url)
-            await message.reply(str(status_dict))
+            status_dict = requests.get(dict_or_url).text
+            await message.reply(status_dict)
         else:
             status_dict = dict_or_url
         try:

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -406,7 +406,7 @@ async def get_version(message: types.Message, manager: Manager, **kwargs):
     await message.reply(f"Версия бота: {msg}")
 
 
-def reset_default(message: types.Message, manager: Manager, **kwargs):
+def reset_to_default(message: types.Message, manager: Manager, **kwargs):
     key = utils.trim_command_name(message, kwargs['command_name']).strip()
     if len(key):
         try:

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -244,7 +244,7 @@ async def update_level(message: types.Message, manager: Manager, **kwargs):
     else:
         game_status = await manager.http_client.status()
     await message.reply(str(game_status))
-    await update_level_status(manager.bot, manager, game_status)
+    await update_level_status(manager.bot, manager, **{'game_status': game_status})
 
 
 async def _process_next_level(status, manager: Manager, silent=True):
@@ -321,10 +321,11 @@ async def _update_current_level_info_on_code(verdict: str, message: types.Messag
 
 
 @safe_dzzzr_interaction
-async def update_level_status(bot: Bot, manager: Manager, game_status: Status = None, **kwargs):
-    forced_update = game_status is not None
+async def update_level_status(bot: Bot, manager: Manager, **kwargs):
+    forced_update = 'game_status' in kwargs
+    game_status = kwargs['game_status']
     if manager.state.parse_on or forced_update:
-        if not game_status:
+        if not forced_update:
             game_status = await manager.http_client.status()
         current_level_id = game_status.current_level.levelNumber
         if not manager.state.game_status:

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -77,11 +77,10 @@ async def send_ko(message: types.Message, manager: Manager, **kwargs):
     koline = await manager.get_or_load_and_parse_koline()
     if not manager.state.tip:
         for sector in koline.sectors:
-            await utils.notify_code_chat(manager.bot, manager, views.sector_default_ko_message(sector, manager.state))
+            await utils.notify_code_chat(manager, views.sector_default_ko_message(sector, manager.state))
     else:
         for sector, sector_tip in zip(koline.sectors, manager.state.tip):
-            await utils.notify_code_chat(manager.bot, manager,
-                                         views.not_taken_with_tips(sector, sector_tip, manager.state))
+            await utils.notify_code_chat(manager, views.not_taken_with_tips(sector, sector_tip, manager.state))
 
 
 async def process_link(message: types.Message, manager: Manager, **kwargs):
@@ -270,7 +269,8 @@ async def _process_next_level(status, manager: Manager, silent=True):
                 try:
                     await utils.image_to_all_channels(manager, "Схема захода: \n", schema_url)
                 except Exception as e:
-                    await utils.notify_code_chat()
+                    await utils.notify_debug_chat(manager, f"Не удалось отправить картинку по адресу {schema_url}")
+                    await utils.notify_debug_chat(manager, e)
         else:
             await utils.notify_all_channels(manager, "Схема захода: Не удалось распарсить")
     if status.current_level.locationComment:

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 from dataclasses import asdict
 import datetime
 import logging
@@ -5,6 +6,7 @@ import os
 import re
 import decorator
 import pathlib
+import requests
 from aiogram.types import InputFile
 from marshmallow import EXCLUDE
 
@@ -229,9 +231,14 @@ async def process_code(message: types.Message, manager: Manager, **kwargs):
 @safe_dzzzr_interaction
 async def update_level(message: types.Message, manager: Manager, **kwargs):
     if len(message.text) >= len("/st "):
-        forced_text_status = message.text[3:]
+        dict_or_url = message.text[3:].strip()
+        if not dict_or_url.startswith('{'):
+            status_dict = requests.get(dict_or_url)
+            await message.reply(str(status_dict))
+        else:
+            status_dict = dict_or_url
         try:
-            status = StatusSchema(partial=True, unknown=EXCLUDE).load(eval(forced_text_status))
+            status = StatusSchema(partial=True, unknown=EXCLUDE).load(literal_eval(status_dict))
         except Exception as e:
             status = StatusSchema(partial=True, unknown=EXCLUDE).load({})
             await message.reply('Не удалось распарсить игровой статус: {}'.format(e))

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -231,9 +231,9 @@ async def update_level(message: types.Message, manager: Manager, **kwargs):
     if len(message.text) >= len("/st "):
         forced_text_status = message.text[3:]
         try:
-            status = StatusSchema(partial=True, unknown=EXCLUDE).load(forced_text_status)
+            status = StatusSchema(partial=True, unknown=EXCLUDE).load(eval(forced_text_status))
         except Exception as e:
-            status = StatusSchema()
+            status = StatusSchema(partial=True, unknown=EXCLUDE).load({})
             await message.reply('Не удалось распарсить игровой статус: {}'.format(e))
     else:
         status = await manager.http_client.status()

--- a/pewpewbot/commands_processing.py
+++ b/pewpewbot/commands_processing.py
@@ -406,7 +406,7 @@ async def get_version(message: types.Message, manager: Manager, **kwargs):
     await message.reply(f"Версия бота: {msg}")
 
 
-def reset_to_default(message: types.Message, manager: Manager, **kwargs):
+async def reset_to_default(message: types.Message, manager: Manager, **kwargs):
     key = utils.trim_command_name(message, kwargs['command_name']).strip()
     if len(key):
         try:

--- a/pewpewbot/patterns.py
+++ b/pewpewbot/patterns.py
@@ -8,7 +8,7 @@ STANDARD_CODE_PATTERN = r'\d*[dr]\d*[dr]\d*'
 # Pattern for command with forced code
 FORCED_CODE_PATTERN = r'^/ '
 # Pattern for Level Scheme link parsing
-SCHEMA_LINK_PATTERN = r'<a href=\"\.\.\/\.\.\/(uploaded.*?)\".*?схема.*?<\/a>'
+SCHEMA_LINK_PATTERN = r'<a href=\"\.\.\/\.\.\/(uploaded.*?)\".*?[с|с][х|Х][е|Е][м|М][а|А].*?<\/a>'
 
 ################################################################################
 # Current block is for direct bot commands patterns

--- a/pewpewbot/patterns.py
+++ b/pewpewbot/patterns.py
@@ -8,7 +8,7 @@ STANDARD_CODE_PATTERN = r'\d*[dr]\d*[dr]\d*'
 # Pattern for command with forced code
 FORCED_CODE_PATTERN = r'^/ '
 # Pattern for Level Scheme link parsing
-SCHEMA_LINK_PATTERN = r'<a href=\"\.\.\/\.\.\/(uploaded.*?)\".*?[с|с][х|Х][е|Е][м|М][а|А].*?<\/a>'
+SCHEMA_LINK_PATTERN = r'<a href=\"\.\.\/\.\.\/(uploaded.*?)\".*?[с|С][х|Х][е|Е][м|М][а|А].*?<\/a>'
 
 ################################################################################
 # Current block is for direct bot commands patterns

--- a/pewpewbot/utils.py
+++ b/pewpewbot/utils.py
@@ -77,6 +77,11 @@ async def notify_code_chat(bot: Bot, manager: Manager, message: types.message):
         await bot.send_message(manager.state.code_chat_id, message, parse_mode='Markdown')
 
 
+async def notify_debug_chat(bot: Bot, manager: Manager, message: types.message):
+    if manager.state.debug_chat_id is not None:
+        await bot.send_message(manager.state.debug_chat_id, message, parse_mode='Markdown')
+
+
 def get_text_mode_status(mode):
     return "включен" if mode else "выключен"
 

--- a/pewpewbot/utils.py
+++ b/pewpewbot/utils.py
@@ -115,5 +115,5 @@ async def repeat_runtime_delay(manager: Manager, key: str, coro, *args, **kwargs
 
 
 def get_schema_urls(level_message):
-    links = re.findall(patterns.SCHEMA_LINK_PATTERN, level_message.lower())
+    links = re.findall(patterns.SCHEMA_LINK_PATTERN, level_message)
     return tuple(DZZZR_UPLOADED_FILES_LINK + link for link in links)

--- a/pewpewbot/utils.py
+++ b/pewpewbot/utils.py
@@ -72,14 +72,14 @@ async def image_to_all_channels(manager: Manager, message: types.message, link: 
         await manager.bot.send_photo(manager.state.main_chat_id, link, message, parse_mode='Markdown')
 
 
-async def notify_code_chat(bot: Bot, manager: Manager, message: types.message):
+async def notify_code_chat(manager: Manager, message: types.message):
     if manager.state.code_chat_id is not None:
-        await bot.send_message(manager.state.code_chat_id, message, parse_mode='Markdown')
+        await manager.bot.send_message(manager.state.code_chat_id, message, parse_mode='Markdown')
 
 
-async def notify_debug_chat(bot: Bot, manager: Manager, message: types.message):
+async def notify_debug_chat(manager: Manager, message: types.message):
     if manager.state.debug_chat_id is not None:
-        await bot.send_message(manager.state.debug_chat_id, message, parse_mode='Markdown')
+        await manager.bot.send_message(manager.state.debug_chat_id, message, parse_mode='Markdown')
 
 
 def get_text_mode_status(mode):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ marshmallow-enum==1.3
 decorator==5.0.9
 python-json-logger==2.0.1
 arsenic==20.9
+requests==2.25.1


### PR DESCRIPTION
Удобно для ручного тестирования фичей, которые завязаны на изменение статуса. Например, на появление подсказки или смены уровня.

Для удобства ручного тестирования здесь добавлены команды reset и pin_chat